### PR TITLE
Fixes issue #16

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -47,9 +47,9 @@ graphics_draw_text(ctx, text,
     GTextAlignmentLeft, NULL);
 }
 
-void timer_draw_row(Timer* timer, GContext* ctx) {
+void timer_draw_row(Timer* timer, TimerTimestamp timestamp, GContext* ctx) {
   char* time_left = malloc(12);
-  timer_time_str(timer->current_time, settings()->timers_hours, time_left, 12);
+  timer_display_str(timer, timestamp, settings()->timers_hours, time_left, 12);
 
   graphics_context_set_text_color(ctx, GColorBlack);
   graphics_context_set_fill_color(ctx, GColorBlack);
@@ -95,7 +95,7 @@ void timer_draw_row(Timer* timer, GContext* ctx) {
   }
 
   if (timer->type == TIMER_TYPE_TIMER) {
-    uint8_t width = (144 * timer->current_time) / timer->length;
+    uint8_t width = (144 * timer_get_display_time(timer, timestamp)) / timer->length;
     graphics_fill_rect(ctx, GRect(0, 31, width, 2), 0, GCornerNone);
   }
 

--- a/src/common.h
+++ b/src/common.h
@@ -35,6 +35,6 @@ src/common.h
 #include "timer.h"
 
 void menu_draw_row_icon_text(GContext* ctx, char* text, GBitmap* icon);
-void timer_draw_row(Timer* timer, GContext* ctx);
+void timer_draw_row(Timer* timer, TimerTimestamp reference, GContext* ctx);
 void menu_draw_option(GContext* ctx, char* option, char* value);
 void uppercase(char* str);

--- a/src/migration.h
+++ b/src/migration.h
@@ -93,6 +93,27 @@ typedef struct {
   time_t save_time;
 } TimerBlockTiny;
 
+typedef struct TimerV3 {
+  uint16_t id;
+  TimerType type;
+  uint32_t length;
+  uint32_t current_time;
+  TimerStatus status;
+  TimerVibration vibration;
+  uint8_t repeat;
+  uint8_t repeat_count;
+  AppTimer* timer;
+  WakeupId wakeup_id;
+  char label[24];
+} TimerV3;
+
+typedef struct {
+  TimerV3 timers[TIMER_BLOCK_SIZE];
+  uint8_t total_timers;
+  time_t save_time;
+} TimerBlockV3;
+
+
 // Struct of the original settings.
 typedef struct {
   bool save_timers_auto; // Automatically save timers on exit and load them when the app restarts?

--- a/src/timer.c
+++ b/src/timer.c
@@ -45,7 +45,9 @@ static void timer_transition_to_stop(Timer* timer, TimerTimestamp reference_time
 static void timer_transition_to_start(Timer* timer, TimerTimestamp reference_time);
 static void timer_transition_to(Timer* timer, TimerTimestamp reference_time, TimerStatus new_status);
 static void timer_set_running_time(Timer* timer, TimerTimestamp reference_time, int32_t running_time);
+static void timer_add_running_time(Timer* timer, int32_t add_seconds);
 static bool timer_has_finished(Timer* timer, TimerTimestamp reference);
+static uint32_t timer_display2running_time(Timer* timer, uint32_t display_time);
 
 TimerTimestamp timer_get_end_timestamp(Timer* timer) {
   switch (timer->type) {
@@ -91,6 +93,18 @@ int32_t timer_get_display_time(Timer* timer, TimerTimestamp reference_time) {
     case TIMER_TYPE_STOPWATCH: return timer_get_running_time(timer, reference_time);
     default: return 0;
  }
+}
+
+static uint32_t timer_display2running_time(Timer* timer, uint32_t display_time) {
+  switch (timer->type) {
+    case TIMER_TYPE_TIMER: return timer->length - display_time;
+    case TIMER_TYPE_STOPWATCH: return display_time;
+    default: return 0;
+  }
+}
+
+static void timer_add_running_time(Timer* timer, int32_t add_seconds) {
+  timer->paused_offset += add_seconds;
 }
 
 void timer_time_str(uint32_t timer_time, bool showHours, char* str, int str_len) {
@@ -153,6 +167,13 @@ void timer_restore(Timer* timer, TimerTimestamp reference) {
   if (timer->status == TIMER_STATUS_RUNNING) {
     timer_resume(timer, reference);
   }
+}
+
+void timer_restore_legacy(Timer* timer, TimerTimestamp reference, uint32_t offset, uint32_t display_time) {
+  uint32_t running_time = timer_display2running_time(timer, display_time);
+  timer_set_running_time(timer, reference, running_time);
+  timer_add_running_time(timer, offset);
+  timer_restore(timer, reference);
 }
 
 Timer* timer_clone(Timer* timer) {

--- a/src/timer.c
+++ b/src/timer.c
@@ -172,7 +172,9 @@ void timer_restore(Timer* timer, TimerTimestamp reference) {
 void timer_restore_legacy(Timer* timer, TimerTimestamp reference, uint32_t offset, uint32_t display_time) {
   uint32_t running_time = timer_display2running_time(timer, display_time);
   timer_set_running_time(timer, reference, running_time);
-  timer_add_running_time(timer, offset);
+  if (TIMER_STATUS_RUNNING == timer->status) {
+    timer_add_running_time(timer, offset);
+  }
   timer_restore(timer, reference);
 }
 

--- a/src/timer.h
+++ b/src/timer.h
@@ -54,16 +54,18 @@ typedef enum {
   TIMER_STATUS_DONE = 3,
 } TimerStatus;
 
+typedef time_t TimerTimestamp;
+
 typedef struct Timer {
   uint16_t id;
   TimerType type;
   uint32_t length;
-  uint32_t current_time;
+  int32_t paused_offset;
+  TimerTimestamp start_timestamp;
   TimerStatus status;
   TimerVibration vibration;
   uint8_t repeat;
   uint8_t repeat_count;
-  AppTimer* timer;
   WakeupId wakeup_id;
   char label[24];
 } Timer;
@@ -71,12 +73,18 @@ typedef struct Timer {
 #define TIMER_REPEAT_INFINITE 100
 
 void timer_time_str(uint32_t timer_time, bool showHours, char* str, int str_len);
-void timer_start(Timer* timer);
-void timer_pause(Timer* timer);
-void timer_resume(Timer* timer);
+void timer_display_str(Timer* timer, TimerTimestamp reference, bool showHours, char* str, int str_len);
+void timer_start(Timer* timer, TimerTimestamp reference);
+void timer_pause(Timer* timer, TimerTimestamp reference);
+void timer_resume(Timer* timer, TimerTimestamp reference);
 void timer_reset(Timer* timer);
-void timer_restore(Timer* timer, uint16_t seconds_elapsed);
+void timer_restart(Timer* timer, TimerTimestamp reference);
+void timer_restore(Timer* timer, TimerTimestamp reference);
 Timer* timer_clone(Timer* timer);
 char* timer_vibe_str(TimerVibration vibe, bool shortStr);
 Timer* timer_create_timer(void);
 Timer* timer_create_stopwatch(void);
+void timer_tick(Timer* timer, TimerTimestamp reference);
+uint32_t timer_get_running_time(Timer* timer, TimerTimestamp reference);
+TimerTimestamp timer_get_end_timestamp(Timer* timer);
+int32_t timer_get_display_time(Timer* timer, TimerTimestamp reference);

--- a/src/timer.h
+++ b/src/timer.h
@@ -80,6 +80,7 @@ void timer_resume(Timer* timer, TimerTimestamp reference);
 void timer_reset(Timer* timer);
 void timer_restart(Timer* timer, TimerTimestamp reference);
 void timer_restore(Timer* timer, TimerTimestamp reference);
+void timer_restore_legacy(Timer* timer, TimerTimestamp reference, uint32_t offset, uint32_t display_time);
 Timer* timer_clone(Timer* timer);
 char* timer_vibe_str(TimerVibration vibe, bool shortStr);
 Timer* timer_create_timer(void);

--- a/src/timers.c
+++ b/src/timers.c
@@ -172,20 +172,21 @@ void timers_clear(void) {
 }
 
 void timers_mark_updated(void) {
-  if (queue_updates) {
-    update_marked = true;
-  } else {
+  update_marked = true;
+  if (!queue_updates) {
     timers_fire_update_handlers();
-    update_marked = false;
   }
 }
 
 void timers_fire_update_handlers(void) {
-  uint8_t handler_count = linked_list_count(update_handlers);
-  for (uint8_t h = 0; h < handler_count; h += 1) {
-    TimersUpdatedHandler handler = linked_list_get(update_handlers, h);
-    handler();
+  if (update_marked) {
+    uint8_t handler_count = linked_list_count(update_handlers);
+    for (uint8_t h = 0; h < handler_count; h += 1) {
+      TimersUpdatedHandler handler = linked_list_get(update_handlers, h);
+      handler();
+    }
   }
+  update_marked = false;
 }
 
 void timers_highlight(Timer* timer) {
@@ -216,10 +217,8 @@ void timers_update_timestamp(void) {
     Timer* timer = timers_get(t);
     timer_tick(timer, current_time);
   }
-  if (update_marked) {
-    timers_fire_update_handlers();
-    queue_updates = false;
-  }
+  queue_updates = false;
+  timers_fire_update_handlers();
 }
 
 TimerTimestamp timers_current_timestamp() {

--- a/src/timers.c
+++ b/src/timers.c
@@ -211,7 +211,8 @@ static TimerTimestamp new_timestamp() {
 void timers_update_timestamp(void) {
   current_time = new_timestamp();
   queue_updates = true;
-  for (uint8_t t = 0; t < timers_count(); ++t) {
+  const uint8_t count = timers_count();
+  for (uint8_t t = 0; t < count; ++t) {
     Timer* timer = timers_get(t);
     timer_tick(timer, current_time);
   }

--- a/src/timers.c
+++ b/src/timers.c
@@ -42,7 +42,6 @@ src/timers.c
 typedef struct {
   Timer timers[TIMER_BLOCK_SIZE];
   uint8_t total_timers;
-  time_t save_time;
 } TimerBlock;
 
 static void timers_cleanup(void);
@@ -242,7 +241,6 @@ void timers_save(void) {
     if (NULL == block) {
       block = malloc(sizeof(TimerBlock));
       block->total_timers = timers_count();
-      block->save_time = time(NULL);
     }
 
     uint8_t timer_block_pos = b % TIMER_BLOCK_SIZE;

--- a/src/timers.h
+++ b/src/timers.h
@@ -34,7 +34,8 @@ src/timers.h
 
 #define TIMER_BLOCK_SIZE 4
 
-#define TIMERS_VERSION_CURRENT 3
+#define TIMERS_VERSION_CURRENT 4
+#define TIMERS_VERSION_V3 3
 #define TIMERS_VERSION_TINY 2
 
 typedef void (*TimersUpdatedHandler)(void);

--- a/src/timers.h
+++ b/src/timers.h
@@ -78,6 +78,9 @@ Timer* timers_find_wakeup_collision(Timer* timer);
 // Empty list the timers.
 void timers_clear(void);
 
+void timers_update_timestamp(void);
+TimerTimestamp timers_current_timestamp();
+
 void timers_mark_updated(void);
 void timers_highlight(Timer* timer);
 void timers_register_update_handler(TimersUpdatedHandler handler);

--- a/src/windows/win-controls.c
+++ b/src/windows/win-controls.c
@@ -113,6 +113,7 @@ static void menu_draw_row(GContext* ctx, const Layer* cell_layer, MenuIndex* cel
 
 static void menu_select(struct MenuLayer* menu, MenuIndex* cell_index, void* callback_context) {
   uint8_t num_timers = timers_count();
+  TimerTimestamp timestamp = timers_current_timestamp();
   switch (cell_index->row) {
     case MENU_ROW_RESUME:
       for (uint8_t t = 0; t < num_timers; t += 1) {
@@ -121,14 +122,14 @@ static void menu_select(struct MenuLayer* menu, MenuIndex* cell_index, void* cal
           case TIMER_STATUS_RUNNING:
             break;
           case TIMER_STATUS_PAUSED:
-            timer_resume(timer);
+            timer_resume(timer, timestamp);
             break;
           case TIMER_STATUS_DONE:
             timer_reset(timer);
-            timer_start(timer);
+            timer_start(timer, timestamp);
             break;
           case TIMER_STATUS_STOPPED:
-            timer_start(timer);
+            timer_start(timer, timestamp);
             break;
         }
       }
@@ -137,7 +138,7 @@ static void menu_select(struct MenuLayer* menu, MenuIndex* cell_index, void* cal
       for (uint8_t t = 0; t < num_timers; t += 1) {
         Timer* timer = timers_get(t);
         if (timer->status == TIMER_STATUS_RUNNING) {
-          timer_pause(timer);
+          timer_pause(timer, timestamp);
         }
       }
       break;

--- a/src/windows/win-timer-add.c
+++ b/src/windows/win-timer-add.c
@@ -209,6 +209,7 @@ static void menu_select_main(uint16_t row) {
 }
 
 static void menu_select_footer(void) {
+  TimerTimestamp timestamp = timers_current_timestamp();
   if (s_timer->length == 0) {
     vibes_short_pulse();
     menu_layer_set_selected_index(s_menu, (MenuIndex) { MENU_SECTION_MAIN, MENU_ROW_DURATION }, MenuRowAlignCenter, true);
@@ -228,7 +229,7 @@ static void menu_select_footer(void) {
     Timer* timer = timer_clone(s_timer);
     timer_reset(timer);
     if (settings()->timers_start_auto) {
-      timer_start(timer);
+      timer_start(timer, timestamp);
     }
     timers_add(timer);
     window_stack_pop(true);

--- a/src/windows/win-timer.c
+++ b/src/windows/win-timer.c
@@ -110,7 +110,7 @@ static void window_unload(Window* window) {
 }
 
 static void layer_header_update(Layer* layer, GContext* ctx) {
-  timer_draw_row(s_timer, ctx);
+  timer_draw_row(s_timer, timers_current_timestamp(), ctx);
 }
 
 static uint16_t menu_num_sections(struct MenuLayer* menu, void* callback_context) {
@@ -155,18 +155,19 @@ static void menu_draw_row(GContext* ctx, const Layer* cell_layer, MenuIndex* cel
 }
 
 static void menu_select(struct MenuLayer* menu, MenuIndex* cell_index, void* callback_context) {
+  TimerTimestamp timestamp = timers_current_timestamp();
   switch (cell_index->row) {
     case MENU_ROW_PAUSE: {
       switch (s_timer->status) {
         case TIMER_STATUS_RUNNING:
-          timer_pause(s_timer);
+          timer_pause(s_timer, timestamp);
           break;
         case TIMER_STATUS_PAUSED:
-          timer_resume(s_timer);
+          timer_resume(s_timer, timestamp);
           break;
         case TIMER_STATUS_DONE:
         case TIMER_STATUS_STOPPED:
-          timer_start(s_timer);
+          timer_start(s_timer, timestamp);
           break;
       }
       break;

--- a/tests/timers.c
+++ b/tests/timers.c
@@ -201,7 +201,7 @@ char* timer_str(void) {
   return 0;
 }
 
-char* timers_migrate_from_1_to_3(void) {
+char* timers_migrate_from_1_to_4(void) {
   OldTimerBlock* block = malloc(sizeof(OldTimerBlock));
   block->count = 2;
   block->time = time(NULL);
@@ -218,25 +218,25 @@ char* timers_migrate_from_1_to_3(void) {
   free(block);
 
   timers_restore();
-  mu_assert(2 == timers_count(), "Migrate 1->3: Incorrect number of timers");
+  mu_assert(2 == timers_count(), "Migrate 1->4: Incorrect number of timers");
 
   Timer* tmr1 = timers_get(0);
   Timer* tmr2 = timers_get(1);
 
-  mu_assert(tmr1->type == TIMER_TYPE_TIMER, "Migrate 1->3: Timer 1 wrong type");
-  mu_assert(tmr1->length == 3000, "Migrate 1->3: Timer 1 wrong length");
-  mu_assert(tmr1->current_time == 200, "Migrate 1->3: Timer 1 wrong time");
-  mu_assert(tmr1->status == TIMER_STATUS_PAUSED, "Migrate 1->3: Timer 1 wrong status");
-  mu_assert(tmr1->repeat == TIMER_REPEAT_INFINITE, "Migrate 1->3: Timer 1 wrong repeat");
-  mu_assert(tmr1->vibration == TIMER_VIBE_DOUBLE , "Migrate 1->3: Timer 1 wrong vibration");
-  mu_assert(tmr2->type == TIMER_TYPE_STOPWATCH , "Migrate 1->3: Timer 2 wrong type");
-  mu_assert(tmr2->current_time == 50, "Migrate 1->3: Timer 2 wrong time");
-  mu_assert(tmr2->status == TIMER_STATUS_RUNNING , "Migrate 1->3: Timer 2 wrong status");
+  mu_assert(tmr1->type == TIMER_TYPE_TIMER, "Migrate 1->4: Timer 1 wrong type");
+  mu_assert(tmr1->length == 3000, "Migrate 1->4: Timer 1 wrong length");
+  mu_assert(timer_get_display_time(tmr1, timers_current_timestamp()) == 200, "Migrate 1->4: Timer 1 wrong time");
+  mu_assert(tmr1->status == TIMER_STATUS_PAUSED, "Migrate 1->4: Timer 1 wrong status");
+  mu_assert(tmr1->repeat == TIMER_REPEAT_INFINITE, "Migrate 1->4: Timer 1 wrong repeat");
+  mu_assert(tmr1->vibration == TIMER_VIBE_DOUBLE , "Migrate 1->4: Timer 1 wrong vibration");
+  mu_assert(tmr2->type == TIMER_TYPE_STOPWATCH , "Migrate 1->4: Timer 2 wrong type");
+  mu_assert(timer_get_display_time(tmr2, timers_current_timestamp()) == 50, "Migrate 1->4: Timer 2 wrong time");
+  mu_assert(tmr2->status == TIMER_STATUS_RUNNING , "Migrate 1->4: Timer 2 wrong status");
 
   return 0;
 }
 
-char* timers_migrate_from_2_to_3(void) {
+char* timers_migrate_from_2_to_4(void) {
   TimerBlockTiny* block = malloc(sizeof(TimerBlockTiny));
   block->total_timers = 2;
   block->save_time = time(NULL);
@@ -261,27 +261,78 @@ char* timers_migrate_from_2_to_3(void) {
   free(block);
 
   timers_restore();
-  mu_assert(2 == timers_count(), "Migrate 2->3: Incorrect number of timers");
+  mu_assert(2 == timers_count(), "Migrate 2->4: Incorrect number of timers");
 
   Timer* tmr1 = timers_get(0);
   Timer* tmr2 = timers_get(1);
 
-  mu_assert(tmr1->type == TIMER_TYPE_TIMER, "Migrate 2->3: Timer 1 wrong type");
-  mu_assert(tmr1->length == 60, "Migrate 2->3: Timer 1 wrong length");
-  mu_assert(tmr1->current_time == 45, "Migrate 2->3: Timer 1 wrong current time");
-  mu_assert(tmr1->id == 5, "Migrate 2->3: Timer 1 wrong ID");
-  mu_assert(0 == strcmp(tmr1->label, "LABEL #1"), "Migrate 2->3: Timer 1 wrong label");
-  mu_assert(tmr1->repeat == TIMER_REPEAT_INFINITE, "Migrate 2->3: Timer 1 wrong repeat");
-  mu_assert(tmr1->vibration == TIMER_VIBE_SOLID, "Migrate 2->3: Timer 1 wrong vibration");
-  mu_assert(tmr1->status == TIMER_STATUS_PAUSED, "Migrate 2->3: Timer 1 wrong status");
-  mu_assert(tmr1->wakeup_id == 70, "Migrate 2->3: Timer 1 wrong wakeup ID");
+  mu_assert(tmr1->type == TIMER_TYPE_TIMER, "Migrate 2->4: Timer 1 wrong type");
+  mu_assert(tmr1->length == 60, "Migrate 2->4: Timer 1 wrong length");
+  mu_assert(timer_get_display_time(tmr1, timers_current_timestamp()) == 45, "Migrate 2->4: Timer 1 wrong display time");
+  mu_assert(tmr1->id == 5, "Migrate 2->4: Timer 1 wrong ID");
+  mu_assert(0 == strcmp(tmr1->label, "LABEL #1"), "Migrate 2->4: Timer 1 wrong label");
+  mu_assert(tmr1->repeat == TIMER_REPEAT_INFINITE, "Migrate 2->4: Timer 1 wrong repeat");
+  mu_assert(tmr1->vibration == TIMER_VIBE_SOLID, "Migrate 2->4: Timer 1 wrong vibration");
+  mu_assert(tmr1->status == TIMER_STATUS_PAUSED, "Migrate 2->4: Timer 1 wrong status");
+  mu_assert(tmr1->wakeup_id == 70, "Migrate 2->4: Timer 1 wrong wakeup ID");
 
-  mu_assert(tmr2->type == TIMER_TYPE_STOPWATCH, "Migrate 2->3: Timer 2 wrong wakeup type");
-  mu_assert(tmr2->current_time == 500, "Migrate 2->3: Timer 2 wrong current time");
-  mu_assert(tmr2->id == 10, "Migrate 2->3: Timer 2 wrong id");
-  mu_assert(0 == strcmp(tmr2->label, "LABEL #2"), "Migrate 2->3: Timer 2 wrong label");
-  mu_assert(tmr2->status == TIMER_STATUS_RUNNING, "Migrate 2->3: Timer 2 wrong status");
-  mu_assert(tmr2->wakeup_id == 60, "Migrate 2->3: Timer 2 wrong wakeup ID");
+  mu_assert(tmr2->type == TIMER_TYPE_STOPWATCH, "Migrate 2->4: Timer 2 wrong wakeup type");
+  mu_assert(timer_get_display_time(tmr2, timers_current_timestamp()) == 500, "Migrate 2->4: Timer 2 wrong display time");
+  mu_assert(tmr2->id == 10, "Migrate 2->4: Timer 2 wrong id");
+  mu_assert(0 == strcmp(tmr2->label, "LABEL #2"), "Migrate 2->4: Timer 2 wrong label");
+  mu_assert(tmr2->status == TIMER_STATUS_RUNNING, "Migrate 2->4: Timer 2 wrong status");
+  mu_assert(tmr2->wakeup_id == 60, "Migrate 2->4: Timer 2 wrong wakeup ID");
+
+  return 0;
+}
+
+char* timers_migrate_from_3_to_4(void) {
+
+  TimerBlockV3* block = malloc(sizeof(TimerBlockV3));
+  block->total_timers = 2;
+  block->save_time = time(NULL);
+  block->timers[0].type = TIMER_TYPE_TIMER;
+  block->timers[0].length = 75;
+  block->timers[0].current_time = 45;
+  block->timers[0].id = 20;
+  strcpy(block->timers[0].label, "LABEL #1");
+  block->timers[0].repeat = TIMER_REPEAT_INFINITE;
+  block->timers[0].vibration = TIMER_VIBE_SOLID;
+  block->timers[0].status = TIMER_STATUS_PAUSED;
+  block->timers[0].wakeup_id = 70;
+  block->timers[1].type = TIMER_TYPE_STOPWATCH;
+  block->timers[1].current_time = 500;
+  block->timers[1].id = 10;
+  strcpy(block->timers[1].label, "LABEL #2");
+  block->timers[1].status = TIMER_STATUS_RUNNING;
+  block->timers[1].wakeup_id = 60;
+
+  persist_write_data(PERSIST_TIMER_START, block, sizeof(TimerBlockV3));
+  persist_write_int(PERSIST_TIMERS_VERSION, TIMERS_VERSION_V3);
+  free(block);
+
+  timers_restore();
+  mu_assert(2 == timers_count(), "Migrate 3->4: Incorrect number of timers");
+
+  Timer *tmr1 = timers_get(0);
+  Timer *tmr2 = timers_get(1);
+
+  mu_assert(tmr1->type == TIMER_TYPE_TIMER, "Migrate 3->4: Timer 1 wrong type");
+  mu_assert(tmr1->length == 75, "Migrate 3->4: Timer 1 wrong length");
+  mu_assert(timer_get_display_time(tmr1, timers_current_timestamp()) == 45, "Migrate 3->4: Timer 1 wrong display time");
+  mu_assert(tmr1->id == 20, "Migrate 3->4: Timer 1 wrong id");
+  mu_assert(0 == strcmp(tmr1->label, "LABEL #1"), "Migrate 3->4: Timer 1 wrong label");
+  mu_assert(tmr1->repeat == TIMER_REPEAT_INFINITE, "Migrate 3->4: Timer 1 wrong repeat");
+  mu_assert(tmr1->vibration == TIMER_VIBE_SOLID, "Migrate 3->4: Timer 1 wrong vibration");
+  mu_assert(tmr1->status == TIMER_STATUS_PAUSED, "Migrate 3->4: Timer 1 wrong status");
+  mu_assert(tmr1->wakeup_id == 70, "Migrate 3->4: Timer 1 wrong wakeup_id");
+
+  mu_assert(tmr2->type == TIMER_TYPE_STOPWATCH, "Migrate 3->4: Timer 2 wrong type");
+  mu_assert(timer_get_display_time(tmr2, timers_current_timestamp()) == 500, "Migrate 3->4: Timer 2 wrong display time");
+  mu_assert(tmr2->id == 10, "Migrate 3->4: Timer 2 wrong id");
+  mu_assert(0 == strcmp(tmr2->label, "LABEL #2"), "Migrate 3->4: Timer 2 wrong label");
+  mu_assert(tmr2->status == TIMER_STATUS_RUNNING, "Migrate 3->4: Timer 2 wrong status");
+  mu_assert(tmr2->wakeup_id == 60, "Migrate 3->4: Timer 2 wrong wakeup_id");
 
   return 0;
 }
@@ -303,7 +354,8 @@ char* timers_tests(void) {
   mu_run_test(timers_save_persists_one_timer);
   mu_run_test(timers_save_persists_multiple_timers);
   mu_run_test(timer_str);
-  mu_run_test(timers_migrate_from_1_to_3);
-  mu_run_test(timers_migrate_from_2_to_3);
+  mu_run_test(timers_migrate_from_1_to_4);
+  mu_run_test(timers_migrate_from_2_to_4);
+  mu_run_test(timers_migrate_from_3_to_4);
   return 0;
 }


### PR DESCRIPTION
Rewrite the way timers keep track of time, preventing interference caused by intrinsic delays on app launch, background, persist tasks, system timer scheduling, etc.
